### PR TITLE
Remove forced lowercase

### DIFF
--- a/themes/quattro.css
+++ b/themes/quattro.css
@@ -2048,7 +2048,6 @@
   --co-logbutton: var(--cl-gray-700);
   --fs-logbutton: 1em;
   --fw-logbutton: normal;
-  --tt-logbutton: lowercase;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -2881,7 +2880,6 @@
   --fs-starred__page: 1em;
   --ft-starred__page: ;
   --fw-starred__page: ;
-  --tt-starred__page: lowercase;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
I like this theme, but capitalization is an important part of my workflow and some others I've seen. This PR removes the forced lowercasing of the sidebar and might be a useful option to include. If not, I can also maintain the option in my fork.

![image](https://user-images.githubusercontent.com/4088051/122677942-8c1c9780-d1b2-11eb-9914-9effacf0ecf8.png)
